### PR TITLE
Fix ostree assertion bug when fetching a preinstalled container

### DIFF
--- a/classes/fullmetalupdate.bbclass
+++ b/classes/fullmetalupdate.bbclass
@@ -44,7 +44,7 @@ python __anonymous() {
     else:
         hawkbit_http_address = "http://" + hawkbit_hostname + ":" + hawkbit_url_port
 
-    ostree_http_distant_address =  server_host_name + ".local:" + ostree_url_port
+    ostree_http_distant_address = "http://" + server_host_name + ".local:" + ostree_url_port
     ostree_ssh_address = "ssh://" + ostreepush_ssh_user + "@" + ostree_hostname + ":" + ostreepush_ssh_port + "/ostree/repo"
 
     d.setVar('HAWKBIT_VENDOR_NAME', hawkbit_vendor_name)


### PR DESCRIPTION
### Setup

i.MX8 board, warrior branch

### Steps to reproduce bug :

Build the fullmetalupdate-os-package with the container-qt-evcs (or another container)
listed in the PREINSTALLED_CONTAINERS_LIST variable in `meta-fullmetalupdate-extra/recipes-core/images/fullmetalupdate-containers-package.bbappend` (or `.../fullmetalupdate-containers-package_<machine>.inc`). Flash the `.wic` on your target.

Build the qt-evcs container (or another container), and push it to the target from hawkbit.

When the updater tries to fetch the container deltas it fails with :
```
OSTree:ERROR:../git/src/libostree/ostree-fetcher-curl.c:319:check_multi_info: assertion failed: (is_file || g_str_has_prefix (eff_url, "http"))
```

### Solution :

The above address `eff_url` was `<my-hostname>.local:8000/config`. When cross checking in python the remote address for this preinstalled container was in fact `<my-hostname>.local:8000`. So OSTree was complaining that the address neither had `http` nor `file` as a prefix.

Adding the http prefix to `ostree_http_distant_address` in `fullmetalupdate.class` fixes
the issue.

### Note

It seems that the `config.cfg` file generated in the demo does not have a field in case the server supports ssl communication or not. Maybe it should ?