### PR TITLE
Remove sysvinit from the rootfs

### DIFF
--- a/conf/distro/fullmetalupdate-os.conf
+++ b/conf/distro/fullmetalupdate-os.conf
@@ -19,6 +19,8 @@ DISTRO_VERSION[vardepsexclude] = "DATE"
 SDK_VERSION[vardepsexclude] = "DATE"
 
 DISTRO_FEATURES_append = " virtualization systemd sota usrmerge"
+VIRTUAL-RUNTIME_init_manager = "systemd"
+DISTRO_FEATURES_remove = "sysvinit"
 DISTRO_FEATURES_remove = "x11"
 DISTRO_FEATURES_remove = "${@bb.utils.contains_any('MACHINE', ['imx8mqevk'], '', 'wayland', d)}"
 


### PR DESCRIPTION
`sysvinit` is not needed by FMU in the rootfs. It also fixes a bug where `telinit` was being installed by both `systemd` and `sysvinit`.