### PR TITLE
[warrior] Remove machine name from hawkbit distro name

### DIFF
--- a/classes/fullmetalupdate_push_image_to_ostree.bbclass
+++ b/classes/fullmetalupdate_push_image_to_ostree.bbclass
@@ -30,7 +30,7 @@ do_push_image_to_hawkbit_and_ostree() {
     OSTREE_REVPARSE=$(ostree_revparse ${OSTREE_REPO} ${OSTREE_BRANCHNAME})
     hawkbit_metadata_revparse=$(hawkbit_metadata_value 'rev' ${OSTREE_REVPARSE})
 
-    json=$(curl_post "/" '[ { "vendor" : "'${HAWKBIT_VENDOR_NAME}'", "name" : "'${OSTREE_BRANCHNAME}'-'${MACHINE}'", "description" : "'${OSTREE_BRANCHNAME}'", "type" : "os", "version" : "'$(date +%Y%m%d%H%M)'"} ]')
+    json=$(curl_post "/" '[ { "vendor" : "'${HAWKBIT_VENDOR_NAME}'", "name" : "'${OSTREE_BRANCHNAME}'", "description" : "'${OSTREE_BRANCHNAME}'", "type" : "os", "version" : "'$(date +%Y%m%d%H%M)'"} ]')
     prop='id'
     temp=`echo $json | sed 's/\\\\\//\//g' | sed 's/[{}]//g' | awk -v k="text" '{n=split($0,a,","); for (i=1; i<=n; i++) print a[i]}' | sed 's/\"\:\"/\|/g' | sed 's/[\,]/ /g' | sed 's/\"//g' | grep -w $prop`
     id=$(echo ${temp##*|})


### PR DESCRIPTION
This is to avoid a duplicate machine name in hawkbit since the branch now contains the machine name.

See related PR https://github.com/FullMetalUpdate/meta-fullmetalupdate-extra/pull/13.