### PR TITLE
ostree-initrd: reboot in case of failure

### DIFF
--- a/recipes-sota/ostree-initrd/files/reboot_on_failure.patch
+++ b/recipes-sota/ostree-initrd/files/reboot_on_failure.patch
@@ -1,0 +1,19 @@
+diff --git a/init.sh b/init.sh
+index 4818a07..6caacd6 100644
+--- a/init.sh
++++ b/init.sh
+@@ -16,9 +16,8 @@ do_mount_fs() {
+ 
+ bail_out() {
+ 	log_error "$@"
+-	log_info "Rebooting..."
+-	#exec reboot -f
+-	exec sh
++	log_info "Press Enter to avoid automatic reboot. After 30 seconds the system will reboot."
++	read -t 30 || exec reboot -f
+ }
+ 
+ get_ostree_sysroot() {
+-- 
+2.17.1
+

--- a/recipes-sota/ostree-initrd/ostree-initrd.bbappend
+++ b/recipes-sota/ostree-initrd/ostree-initrd.bbappend
@@ -1,0 +1,8 @@
+# Copyright (C) 2019 Witekio
+# Released under the GNU LESSER GENERAL PUBLIC LICENSE Version 2.1 license
+
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+SRC_URI_append = " \
+    file://reboot_on_failure.patch;patchdir=${WORKDIR} \
+"


### PR DESCRIPTION
This patch reboots the device in case of failure. This is used for
rollbacking devices when there is a failure at this stage.

There could be a failure for multiple reasons, such as for example:
 - the ostree kernel command line variables are misconsfigured
 - the kernel lacks MMC the driver, in which case the root filesystem cannot be mounted

In such cases the script would fallback into a shell by default. This pull requests changes this to automatically reboot in such cases, so we can rollback onto the previous ostree commit. Note that sometimes, the shell cannot be instanced - in that case a kernel panic happens, and the watchdog takes care of the reset.