### PR TITLE
Remove inherit on image_repo_manifest in fullmetalupdate_sota.class

### DIFF
--- a/classes/fullmetalupdate_sota.bbclass
+++ b/classes/fullmetalupdate_sota.bbclass
@@ -28,5 +28,3 @@ OSTREE_INITRAMFS_IMAGE = "initramfs-ostree-image"
 OSTREE_BOOTLOADER = 'u-boot'
 
 inherit fullmetalupdate_sota_${MACHINE}
-
-inherit image_repo_manifest


### PR DESCRIPTION
image_repo_manifest is made to create a manifest, but we don't use it.
This class should be inherited into an image recipes, but not in every
Yocto recipe.